### PR TITLE
Add support for Wave files with LIST section

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoSound
-version=0.1.0
+version=0.2.0
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=[EXPERIMENTAL] A simple way to play and analyze audio data using Arduino.

--- a/src/SDWaveFile.h
+++ b/src/SDWaveFile.h
@@ -69,6 +69,7 @@ private:
   int _channels;
   long _frames;
   int _blockAlign;
+  uint32_t _dataOffset;
 };
 
 #endif


### PR DESCRIPTION
Added, in readHeader() internal API, a logic to ignore the extrabytes in fmt header's chunk in WAV file.
I have test the changes with two f.wav files  generated from ffmpeg at a sample rate of 22050 Hz and seems that works.

cc/ @sandeepmistry , @agdl if you can make other test

Resolve https://github.com/arduino-libraries/ArduinoSound/issues/9