### PR TITLE
Avoid warning about redefinition of ARM_MATH_CM0PLUS

### DIFF
--- a/src/AmplitudeAnalyzer.h
+++ b/src/AmplitudeAnalyzer.h
@@ -21,7 +21,9 @@
 
 #include <Arduino.h>
 
+#if !defined(ARM_MATH_CM0PLUS)
 #define ARM_MATH_CM0PLUS
+#endif
 #include <arm_math.h>
 
 #include "AudioAnalyzer.h"

--- a/src/FFTAnalyzer.h
+++ b/src/FFTAnalyzer.h
@@ -21,7 +21,9 @@
 
 #include <Arduino.h>
 
+#if !defined(ARM_MATH_CM0PLUS)
 #define ARM_MATH_CM0PLUS
+#endif
 #include <arm_math.h>
 
 #include "AudioAnalyzer.h"


### PR DESCRIPTION
I was getting warnings from these on newer Arduino SAMD Cores, which would become errors when compiling my own code.