### PR TITLE
AudioOutI2S, AudioInI2S: Add setBufferSize(...) API

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -38,6 +38,8 @@ volume	KEYWORD2
 
 input	KEYWORD2
 
+setBufferSize	KEYWORD2
+
 #######################################
 # Constants (LITERAL1)
 #######################################

--- a/src/AudioInI2S.cpp
+++ b/src/AudioInI2S.cpp
@@ -47,6 +47,15 @@ int AudioInI2SClass::begin(long sampleRate, int bitsPerSample)
   return 1;
 }
 
+#ifdef I2S_HAS_SET_BUFFER_SIZE
+int AudioInI2SClass::begin(long sampleRate, int bitsPerSample, int bufferSize)
+{
+  setBufferSize(bufferSize);
+
+  return begin(sampleRate, bitsPerSample);
+}
+#endif
+
 void AudioInI2SClass::end()
 {
   _sampleRate = -1;

--- a/src/AudioInI2S.cpp
+++ b/src/AudioInI2S.cpp
@@ -16,8 +16,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#include <I2S.h>
-
 #include "AudioInI2S.h"
 
 AudioInI2SClass::AudioInI2SClass() :
@@ -72,6 +70,13 @@ int AudioInI2SClass::channels()
 {
   return 2;
 }
+
+#ifdef I2S_HAS_SET_BUFFER_SIZE
+void AudioInI2SClass::setBufferSize(int bufferSize)
+{
+  I2S.setBufferSize(bufferSize);
+}
+#endif
 
 int AudioInI2SClass::begin()
 {

--- a/src/AudioInI2S.cpp
+++ b/src/AudioInI2S.cpp
@@ -99,9 +99,10 @@ int AudioInI2SClass::reset()
 void AudioInI2SClass::onReceive()
 {
   if (_callbackTriggered) {
-    uint8_t data[512];
+    size_t length = I2S.available();
+    uint8_t data[length];
 
-    read(data, sizeof(data));
+    read(data, length);
   }
 }
 

--- a/src/AudioInI2S.h
+++ b/src/AudioInI2S.h
@@ -19,6 +19,8 @@
 #ifndef _AUDIO_IN_I2S_H_INCLUDED
 #define _AUDIO_IN_I2S_H_INCLUDED
 
+#include <I2S.h>
+
 #include "AudioIn.h"
 
 class AudioInI2SClass : public AudioIn
@@ -33,6 +35,10 @@ public:
   virtual long sampleRate();
   virtual int bitsPerSample();
   virtual int channels();
+
+#ifdef I2S_HAS_SET_BUFFER_SIZE
+  void setBufferSize(int bufferSize);
+#endif
 
 protected:
   virtual int begin();

--- a/src/AudioInI2S.h
+++ b/src/AudioInI2S.h
@@ -30,6 +30,9 @@ public:
   virtual ~AudioInI2SClass();
 
   int begin(long sampleRate, int bitsPerSample);
+#ifdef I2S_HAS_SET_BUFFER_SIZE
+  int begin(long sampleRate, int bitsPerSample, int bufferSize);
+#endif
   virtual void end();
 
   virtual long sampleRate();

--- a/src/AudioOutI2S.cpp
+++ b/src/AudioOutI2S.cpp
@@ -16,8 +16,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
-#include <I2S.h>
-
 #include "AudioOutI2S.h"
 
 AudioOutI2SClass::AudioOutI2SClass() :
@@ -111,6 +109,13 @@ int AudioOutI2SClass::isPaused()
 {
   return _paused;
 }
+
+#ifdef I2S_HAS_SET_BUFFER_SIZE
+void AudioOutI2SClass::setBufferSize(int bufferSize)
+{
+  I2S.setBufferSize(bufferSize);
+}
+#endif
 
 int AudioOutI2SClass::startPlayback(AudioIn& input, bool loop)
 {

--- a/src/AudioOutI2S.cpp
+++ b/src/AudioOutI2S.cpp
@@ -78,11 +78,12 @@ int AudioOutI2SClass::resume()
   _paused = false;
 
   // play some silence to get things going
-  uint8_t silence[512];
-  memset(silence, 0x00, sizeof(silence));
+  size_t length = I2S.availableForWrite();
+  uint8_t silence[length];
+  memset(silence, 0x00, length);
 
-  I2S.write(silence, sizeof(silence));
-  I2S.write(silence, sizeof(silence));
+  I2S.write(silence, length);
+  I2S.write(silence, length);
 
   return 1;
 }
@@ -131,11 +132,12 @@ int AudioOutI2SClass::startPlayback(AudioIn& input, bool loop)
   _input = &input;
   _loop = loop;
 
-  uint8_t silence[512];
-  memset(silence, 0x00, sizeof(silence));
+  size_t length = I2S.availableForWrite();
+  uint8_t silence[length];
+  memset(silence, 0x00, length);
 
-  I2S.write(silence, sizeof(silence));
-  I2S.write(silence, sizeof(silence));
+  I2S.write(silence, length);
+  I2S.write(silence, length);
 
   return 1;
 }
@@ -148,8 +150,8 @@ void AudioOutI2SClass::onTransmit()
 
   int channels = _input->channels();
 
-  uint8_t data[512];
-  size_t length = sizeof(data);
+  size_t length = I2S.availableForWrite();
+  uint8_t data[length];
 
   if (channels == 1) {
     length /= 2;

--- a/src/AudioOutI2S.h
+++ b/src/AudioOutI2S.h
@@ -19,6 +19,8 @@
 #ifndef _AUDIO_OUT_I2S_INCLUDED
 #define _AUDIO_OUT_I2S_INCLUDED
 
+#include <I2S.h>
+
 #include "AudioOut.h"
 
 class AudioOutI2SClass : public AudioOut
@@ -37,6 +39,10 @@ public:
 
   virtual int isPlaying();
   virtual int isPaused();
+
+#ifdef I2S_HAS_SET_BUFFER_SIZE
+  void setBufferSize(int bufferSize);
+#endif
 
 private:
   int startPlayback(AudioIn& input, bool loop);


### PR DESCRIPTION
This depends on https://github.com/arduino/ArduinoCore-samd/pull/402.

For FFT's of the input, sometimes a larger buffer size (default is 512 bytes) is needed for the I2S input, these changes allow you to set the buffer size in bytes. For example:

```
  // adjust the buffer size to be dependent on the FFT size and bits per sample
  // for larger FFT sizes a bigger buffer size is needed
  AudioInI2S.setBufferSize(bitsPerSample * fftSize / 8);
```

I was able to get an 512 size FFT working with this change. Prior to this, the default I2S buffer size of 512 bytes would only allow a max of 256. 1024 size doesn't work do to RAM constraints still.


@tigoe thoughts on this, I think it helps with [PitchDetector.ino](https://github.com/tigoe/SoundExamples/blob/master/ArduinoSound_Examples/PitchDetector/PitchDetector.ino) - but maybe there's something better we can do API wise?