### PR TITLE
Use www subdomain in arduino.cc URLs

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Arduino <info@arduino.cc>
 sentence=[EXPERIMENTAL] A simple way to play and analyze audio data using Arduino.
 paragraph=Currently only supports SAMD21 boards and I2S audio devices.
 category=Other
-url=http://arduino.cc/en/Reference/ArduinoSound
+url=https://www.arduino.cc/en/Reference/ArduinoSound
 architectures=samd
 includes=ArduinoSound.h


### PR DESCRIPTION
www.arduino.cc is Arduino's preferred url.