### PR TITLE
fixed cue() function

### DIFF
--- a/src/SDWaveFile.cpp
+++ b/src/SDWaveFile.cpp
@@ -141,10 +141,10 @@ long SDWaveFile::currentTime()
 int SDWaveFile::cue(long time)
 {
   if (time < 0) {
-    return 1;
+    return 0;
   }
 
-  long offset = (time * _blockAlign) - _dataOffset;
+  long offset = (time * _blockAlign * _sampleRate) + _dataOffset;
 
   if (offset < 0) {
     offset = 0;
@@ -154,12 +154,12 @@ int SDWaveFile::cue(long time)
   offset = (offset / 512) * 512;
 
   if ((uint32_t)offset > _file.size()) {
-    return 1;
+    return 0;
   }
 
   _file.seek(offset);
-
-  return 0;
+  
+  return 1;
 }
 
 int SDWaveFile::begin()


### PR DESCRIPTION
Fixed the cue() function by:
1. correcting the offset formular
2. correcting the return parameter

For the function to work reliably the plyback has to be paused before! The pause call and resume can be embeded in the function... But thats a decision for the Arduino Team! If it isnt embeded the documentation has to be updated!