### PR TITLE
Modernize continuous integration system

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = ,
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,0 +1,28 @@
+name: Check Arduino
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          compliance: specification
+          library-manager: update
+          # Always use this setting for official repositories. Remove for 3rd party projects.
+          official: true
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,6 +23,9 @@ jobs:
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     strategy:
       fail-fast: false
 
@@ -78,4 +81,12 @@ jobs:
             - name: SD
           sketch-paths: |
             - examples
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,20 +1,81 @@
 name: Compile Examples
-on: [push, pull_request]
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
 jobs:
- build:
-   runs-on: ubuntu-latest
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
 
-   strategy:
-     matrix:
-       fqbn: [
-         "arduino:samd:mkrzero"
-       ]
+    strategy:
+      fail-fast: false
 
-   steps:
-     - uses: actions/checkout@v1
-       with:
-         fetch-depth: 1
-     - uses: arduino/actions/libraries/compile-examples@master
-       with:
-         fqbn: ${{ matrix.fqbn }}
-         libraries: SD
+      matrix:
+        board:
+          - fqbn: arduino:samd:arduino_zero_edbg
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkr1000
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrzero
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwifi1010
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrfox1200
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwan1300
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrwan1310
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrgsm1400
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrnb1500
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:mkrvidor4000
+            platforms: |
+              - name: arduino:samd
+          - fqbn: arduino:samd:nano_33_iot
+            platforms: |
+              - name: arduino:samd
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            - name: SD
+          sketch-paths: |
+            - examples
+

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,11 +1,22 @@
 name: Spell Check
-on: [push, pull_request]
-jobs:
- build:
-   runs-on: ubuntu-latest
 
-   steps:
-     - uses: actions/checkout@v1
-       with:
-         fetch-depth: 1
-     - uses: arduino/actions/libraries/spell-check@master
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ArduinoSound
 
-[![Compile Examples Status](https://github.com/arduino-libraries/ArduinoSound/workflows/Compile%20Examples/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions?workflow=Compile+Examples) [![Spell Check Status](https://github.com/arduino-libraries/ArduinoSound/workflows/Spell%20Check/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions?workflow=Spell+Check)
+[![Compile Examples status](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/compile-examples.yml)
 
 A simple way to play and analyze audio data using Arduino. Currently only supports SAMD21 boards and I2S audio devices.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ArduinoSound
 
+[![Check Arduino status](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/check-arduino.yml)
 [![Compile Examples status](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/compile-examples.yml)
 [![Spell Check status](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/spell-check.yml)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ArduinoSound
 
 [![Compile Examples status](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/compile-examples.yml)
+[![Spell Check status](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/ArduinoSound/actions/workflows/spell-check.yml)
 
 A simple way to play and analyze audio data using Arduino. Currently only supports SAMD21 boards and I2S audio devices.
 

--- a/examples/AmplitudeSerialPlotter/AmplitudeSerialPlotter.ino
+++ b/examples/AmplitudeSerialPlotter/AmplitudeSerialPlotter.ino
@@ -1,17 +1,17 @@
 /*
- This example reads audio data from an Invensense's ICS43432 I2S microphone
- breakout board, and prints out the amplitude to the Serial console. The
- Serial Plotter built into the Arduino IDE can be used to plot the audio
- amplitude data (Tools -> Serial Plotter)
+ This example reads audio data from an InvenSense ICS-43432 I2S microphone
+ breakout board, and prints out the amplitude to the Serial Monitor. The
+ Serial Plotter built into the Arduino IDE (Tools -> Serial Plotter) can be
+ used to plot the audio amplitude data.
 
  Circuit:
- * Arduino/Genuino Zero, MKRZero or MKR1000 board
- * ICS43432:
+ * Arduino Zero, MKR Zero or MKR1000 board
+ * ICS-43432:
    * GND connected GND
-   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKRZero)
-   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKRZero)
-   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKRZero)
-   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKRZero)
+   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKR Zero)
+   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKR Zero)
+   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKR Zero)
+   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKR Zero)
 
  created 23 November 2016
  by Sandeep Mistry

--- a/examples/ClapDetector/ClapDetector.ino
+++ b/examples/ClapDetector/ClapDetector.ino
@@ -1,16 +1,16 @@
 /*
- This example reads audio data from an Invensense's ICS43432 I2S microphone
+ This example reads audio data from an InvenSense ICS-43432 I2S microphone
  breakout board, and uses the input to detect clapping sounds. An LED is
- togggled when a clapp is detected.
+ toggled when a clap is detected.
 
  Circuit:
- * Arduino/Genuino Zero, MKRZero or MKR1000 board
- * ICS43432:
+ * Arduino Zero, MKR Zero or MKR1000 board
+ * ICS-43432:
    * GND connected GND
-   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKRZero)
-   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKRZero)
-   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKRZero)
-   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKRZero)
+   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKR Zero)
+   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKR Zero)
+   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKR Zero)
+   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKR Zero)
 
  created 18 November 2016
  by Sandeep Mistry

--- a/examples/SpectrumSerialPlotter/SpectrumSerialPlotter.ino
+++ b/examples/SpectrumSerialPlotter/SpectrumSerialPlotter.ino
@@ -1,17 +1,17 @@
 /*
- This example reads audio data from an Invensense's ICS43432 I2S microphone
- breakout board, and prints out the spectrum to the Serial console. The
- Serial Plotter built into the Arduino IDE can be used to plot the audio
- amplitude data (Tools -> Serial Plotter)
+ This example reads audio data from an InvenSense ICS-43432 I2S microphone
+ breakout board, and prints out the spectrum to the Serial Monitor. The
+ Serial Plotter built into the Arduino IDE (Tools -> Serial Plotter) can be
+ used to plot the audio amplitude data.
 
  Circuit:
- * Arduino/Genuino Zero, MKRZero or MKR1000 board
- * ICS43432:
+ * Arduino Zero, MKR Zero or MKR1000 board
+ * ICS-43432:
    * GND connected GND
-   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKRZero)
-   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKRZero)
-   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKRZero)
-   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKRZero)
+   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKR Zero)
+   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKR Zero)
+   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKR Zero)
+   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKR Zero)
 
  created 21 November 2016
  by Sandeep Mistry

--- a/examples/WavePlayback/WavePlayback.ino
+++ b/examples/WavePlayback/WavePlayback.ino
@@ -1,16 +1,16 @@
 /*
  This reads a wave file from an SD card and plays it using the I2S interface to
- a MAX08357 I2S Amp Breakout board.
+ a MAX98357 I2S Amp Breakout board.
 
  Circuit:
- * Arduino/Genuino Zero, MKRZero or MKR1000 board
+ * Arduino Zero, MKR Zero or MKR1000 board
  * SD breakout or shield connected
- * MAX08357:
+ * MAX98357:
    * GND connected GND
    * VIN connected 5V
-   * LRC connected to pin 0 (Zero) or pin 3 (MKR1000, MKRZero)
-   * BCLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKRZero)
-   * DIN connected to pin 9 (Zero) or pin A6 (MKR1000, MKRZero)
+   * LRC connected to pin 0 (Zero) or pin 3 (MKR1000, MKR Zero)
+   * BCLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKR Zero)
+   * DIN connected to pin 9 (Zero) or pin A6 (MKR1000, MKR Zero)
 
  created 15 November 2016
  by Sandeep Mistry

--- a/examples/WhistleDetector/WhistleDetector.ino
+++ b/examples/WhistleDetector/WhistleDetector.ino
@@ -1,17 +1,17 @@
 /*
- This example reads audio data from an Invensense's ICS43432 I2S microphone
+ This example reads audio data from an InvenSense ICS-43432 I2S microphone
  breakout board, and uses the input to detect whistling sounds at a particular
- frequency. When a whistle is detected, it's level is used to control the
- brightness of an LED
+ frequency. When a whistle is detected, its level is used to control the
+ brightness of an LED.
 
  Circuit:
- * Arduino/Genuino Zero, MKRZero or MKR1000 board
- * ICS43432:
+ * Arduino Zero, MKR Zero or MKR1000 board
+ * ICS-43432:
    * GND connected GND
-   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKRZero)
-   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKRZero)
-   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKRZero)
-   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKRZero)
+   * 3.3V connected 3.3V (Zero) or VCC (MKR1000, MKR Zero)
+   * WS connected to pin 0 (Zero) or pin 3 (MKR1000, MKR Zero)
+   * CLK connected to pin 1 (Zero) or pin 2 (MKR1000, MKR Zero)
+   * SD connected to pin 9 (Zero) or pin A6 (MKR1000, MKR Zero)
 
  created 30 November 2016
  by Sandeep Mistry

--- a/src/SDWaveFile.cpp
+++ b/src/SDWaveFile.cpp
@@ -150,7 +150,7 @@ int SDWaveFile::cue(long time)
     offset = 0;
   }
 
-  // make sure it's multiple of 512
+  // make sure it's a multiple of 512
   offset = (offset / 512) * 512;
 
   if ((uint32_t)offset > _file.size()) {


### PR DESCRIPTION
This PR updates the CI system to the standardized [GitHub Actions](https://github.com/features/actions)-based CI configuration for Arduino libraries.

### Dependabot

Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Spell check

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

### Arduino Lint

On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

### Compile examples

On every push or pull request that affects library source or example files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all example sketches for the specified boards.

### Report size deltas

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

---
Fixes https://github.com/arduino-libraries/ArduinoSound/issues/30