### PR TITLE
Correct header filename in documentation

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -5,6 +5,5 @@ This library provides simple way to play and analyze audio data using Arduino on
 To use this library:
 
 ```
-#include <AudioSound.h>
+#include <ArduinoSound.h>
 ```
-


### PR DESCRIPTION
The reference home page contained an incorrect header file name "AudioSound.h" in the sample `#include` directive:
https://www.arduino.cc/reference/en/libraries/arduinosound/#usage

The correct header file name is [`ArduinoSound.h`](https://github.com/arduino-libraries/ArduinoSound/blob/master/src/ArduinoSound.h)

Fixes (partially?) https://github.com/arduino/Arduino/issues/11623

NOTE: There is an additional occurrence of the error on the bespoke reference page for the library:
https://www.arduino.cc/en/Reference/ArduinoSound
I don't know whether this PR will resolve that one.